### PR TITLE
Add validation of path in post request handler and added handling of delete request without CGI

### DIFF
--- a/src/http-response/post-handler.cpp
+++ b/src/http-response/post-handler.cpp
@@ -1,6 +1,24 @@
 #include "http-response.h"
 #include "http-request.h"
 #include "http-exception.h"
+#include <sys/stat.h>
+#include <unistd.h>
+
+static void validateUploadPath(const std::string& path) {
+    struct stat info;
+    if (stat(path.c_str(), &info) != 0) {
+        // Path does not exist
+        throw HttpException(FORBIDDEN, "Upload path does not exist");
+    }
+    if (!S_ISDIR(info.st_mode)) {
+        // Not a directory
+        throw HttpException(FORBIDDEN, "Upload path is not a directory");
+    }
+    if (access(path.c_str(), W_OK) != 0) {
+        // Not writable
+        throw HttpException(FORBIDDEN, "Upload path is not writable");
+    }
+}
 
 static std::vector<std::string> extractMultipartParts(const std::string& body, const std::string& boundary)
 {

--- a/src/http-response/post-handler.cpp
+++ b/src/http-response/post-handler.cpp
@@ -6,18 +6,12 @@
 
 static void validateUploadPath(const std::string& path) {
     struct stat info;
-    if (stat(path.c_str(), &info) != 0) {
-        // Path does not exist
+    if (stat(path.c_str(), &info) != 0)
         throw HttpException(FORBIDDEN, "Upload path does not exist");
-    }
-    if (!S_ISDIR(info.st_mode)) {
-        // Not a directory
+    if (!S_ISDIR(info.st_mode))
         throw HttpException(FORBIDDEN, "Upload path is not a directory");
-    }
-    if (access(path.c_str(), W_OK) != 0) {
-        // Not writable
+    if (access(path.c_str(), W_OK) != 0)
         throw HttpException(FORBIDDEN, "Upload path is not writable");
-    }
 }
 
 static std::vector<std::string> extractMultipartParts(const std::string& body, const std::string& boundary)
@@ -82,6 +76,8 @@ void HttpResponse::handlePostRequest(const HttpRequest& request, const std::stri
     size_t pos = contentType.find("boundary=");
     if (pos == std::string::npos)
         throw HttpException(BAD_REQUEST, "Missing boundary in Content-Type");
+
+    validateUploadPath(locationPath);
 
     const std::string& body = request.getBody();
     std::string boundary = "--" + contentType.substr(pos + 9);

--- a/src/sockets-polling/handle-connections.cpp
+++ b/src/sockets-polling/handle-connections.cpp
@@ -42,7 +42,6 @@ void dispatchRequest(Connection& connection)
         else if (request.getMethod() == "POST")
             response.handlePostRequest(request, "/objs/"); // objs hardcoded, change to full path without index
         else if (request.getMethod() == "DELETE")
-            // res.handleDeleteRequest(req, connection.config);
             throw HttpException(METHOD_NOT_ALLOWED, "Delete without CGI not allowed");
     }
 }

--- a/src/sockets-polling/handle-connections.cpp
+++ b/src/sockets-polling/handle-connections.cpp
@@ -41,8 +41,9 @@ void dispatchRequest(Connection& connection)
             response.handleGetRequest(request.getURI(), connection.server, connection.location);
         else if (request.getMethod() == "POST")
             response.handlePostRequest(request, "/objs/"); // objs hardcoded, change to full path without index
-        // else if (req.getMethod() == "DELETE")
-        //     res.handleDeleteRequest(req, connection.config);
+        else if (request.getMethod() == "DELETE")
+            // res.handleDeleteRequest(req, connection.config);
+            throw HttpException(METHOD_NOT_ALLOWED, "Delete without CGI not allowed");
     }
 }
 


### PR DESCRIPTION
Post request handler will throw Forbidden if path specified does not exist, is not a directory or is not writable to.
Delete request will be met with 405 method not allowed if it doesn't route to a CGI.